### PR TITLE
docs: refresh README wording and CI reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-Welcome to Yerbas 
+Welcome to Yerbas
 ===========================
 
  
 Introduction
 ------------
 
-WARNING! Yerbas is a work in progress...Use at your own risk!
+WARNING! Yerbas is a work in progress. Use at your own risk!
 
-Yerbas is a community driven, developmental, grassroots, digital currency that enables instant payments to anyone, anywhere in the world. The Yerbas Coin uses peer-to-peer technology to operate with no central authority: managing transactions and issuing money are carried out collectively by the network. Yerbas is a code fork of Bitcoin/Dash/Ravencoin/Raptoreum and inherits current and optionally future features such as chain locks, oracles etc. The inspiration for the name Yerbas is derived from the Latin(herba) and Español(hierba) words for herb, grass, or weeds.
+Yerbas is a community-driven, grassroots digital currency that enables instant payments to anyone, anywhere in the world. Yerbas Coin uses peer-to-peer technology to operate with no central authority: managing transactions and issuing money are carried out collectively by the network. Yerbas is a code fork of Bitcoin, Dash, Ravencoin, and Raptoreum and inherits current (and optionally future) features such as ChainLocks and oracles. The inspiration for the name Yerbas is derived from the Latin (`herba`) and Español (`hierba`) words for herb, grass, or weeds.
 
 
 License
@@ -44,7 +44,7 @@ There are also [regression and integration tests](/test), written
 in Python, that are run automatically on the build server.
 These tests can be run (if the [test dependencies](/test) are installed) with: `test/functional/test_runner.py`
 
-The Travis CI system makes sure that every pull request is built for Windows, Linux, and OS X, and that unit/sanity tests are run automatically.
+Our GitHub Actions workflows make sure that every pull request is built for Windows, Linux, and macOS, and that unit/sanity tests are run automatically.
 
 ### Manual Quality Assurance (QA) Testing.
 


### PR DESCRIPTION
### Motivation
- Improve clarity and modernize the project README wording and CI references for better readability and accuracy.

### Description
- Edit `README.md` to clean up the title and warning punctuation, rephrase the project introduction for readability and consistency (including `community-driven`, `ChainLocks`, and clarified etymology), and replace the outdated Travis CI reference with GitHub Actions and `macOS`.

### Testing
- Validated formatting and whitespace with `git diff --check` and inspected repository status with `git status --short`, both showing no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c61277a2e0832182ce3b91f49c248a)