### PR TITLE
Draft: Yerbas constrained Asset Contract layer

### DIFF
--- a/doc/asset-contract-layer.md
+++ b/doc/asset-contract-layer.md
@@ -1,0 +1,165 @@
+# Yerbas Asset Contract Layer
+
+## Status
+
+This document defines the first implementation milestone for constrained, deterministic contracts attached to Yerbas Assets. It is a design specification only. The initial code must remain inactive until a later consensus deployment explicitly enables contract transaction parsing and execution.
+
+## Goals
+
+The contract layer supports five bounded applications:
+
+1. Escrow
+2. Royalties
+3. Auctions
+4. Atomic asset swaps
+5. Asset-weighted voting
+
+The design intentionally excludes general-purpose computation, arbitrary bytecode, external calls, networking, filesystem access, wall-clock access, floating point, nondeterministic randomness, recursive contract creation, and unrestricted cross-contract calls.
+
+## Contract model
+
+A contract is an immutable template instance associated with one controlling Yerbas Asset. Contract behavior is selected from a consensus-defined template enum rather than uploaded executable code.
+
+Each contract has:
+
+- a deterministic contract ID;
+- a template type and template version;
+- a controlling asset name;
+- an owner destination;
+- immutable creation parameters;
+- bounded mutable state;
+- an execution-unit limit;
+- a lifecycle status.
+
+The contract ID is derived from the deployment transaction outpoint:
+
+```
+contract_id = Hash(deployment_txid || output_index)
+```
+
+## Template types
+
+### Escrow
+
+Locks YERB or Yerbas Assets until one of the following deterministic conditions occurs:
+
+- all required parties approve release;
+- a refund height is reached;
+- a designated arbitrator selects release or refund.
+
+### Royalty
+
+Defines a basis-point royalty and one or more recipients. A royalty contract may be referenced by marketplace settlement transactions. Consensus validates the recipient shares and the maximum total royalty.
+
+### Auction
+
+Supports fixed-duration English auctions with:
+
+- one listed asset lot;
+- YERB-denominated bids;
+- a minimum bid;
+- an optional reserve;
+- a deterministic end height;
+- refund accounting for displaced bids.
+
+### Atomic swap
+
+Locks two asset bundles and completes only when both sides satisfy the declared terms before expiry. Otherwise, each side can reclaim its original bundle after the expiry height.
+
+### Voting
+
+Creates an asset-weighted vote with a fixed snapshot height, option count, start height, and end height. Voting power is derived from consensus-visible asset balances at the declared snapshot and cannot be reused across conflicting votes within one proposal.
+
+## Operations
+
+The first protocol version defines these operations:
+
+- `DEPLOY`
+- `CALL`
+- `CANCEL`
+- `FINALIZE`
+
+Each operation must have a maximum serialized size and a template-specific validation function.
+
+## Determinism rules
+
+Contract evaluation may read only:
+
+- the current block height;
+- the transaction being validated;
+- referenced UTXOs;
+- current Yerbas Asset metadata;
+- the contract's own state;
+- consensus-defined constants.
+
+Contract evaluation must not read median time, local clock time, mempool ordering, peer state, RPC state, environment variables, or external services.
+
+## Resource limits
+
+Initial limits should be conservative and consensus-defined:
+
+- maximum deployment payload: 4 KiB;
+- maximum call payload: 2 KiB;
+- maximum state entries per contract: 256;
+- maximum state key: 64 bytes;
+- maximum state value: 512 bytes;
+- maximum operations per call: 1,000;
+- maximum contracts touched by one transaction: 8.
+
+These values remain provisional until testnet benchmarking is complete.
+
+## Database and undo
+
+Contract metadata and state must use dedicated databases and caches. Every state mutation must produce undo data sufficient to restore the exact previous state during block disconnection and chain reorganization.
+
+Suggested components:
+
+```
+src/assets/assetcontract.h
+src/assets/assetcontract.cpp
+src/assets/assetcontractdb.h
+src/assets/assetcontractdb.cpp
+src/assets/assetcontractvalidation.h
+src/assets/assetcontractvalidation.cpp
+```
+
+## Activation
+
+No contract payload is valid on mainnet until a dedicated consensus deployment activates the feature. Before activation, contract-looking data is treated according to existing script and transaction rules and must not mutate contract state.
+
+Activation requires:
+
+- test vectors;
+- unit tests;
+- functional tests;
+- reorganization tests;
+- malformed-payload tests;
+- resource-limit tests;
+- testnet soak testing;
+- independent security review.
+
+## Milestones
+
+### Milestone 1
+
+Define serialized types, template limits, IDs, lifecycle status, and context-free validation. No consensus wiring.
+
+### Milestone 2
+
+Add contract database, cache, and undo records with unit tests.
+
+### Milestone 3
+
+Add inactive transaction parsing and RPC decoding behind a regtest-only feature flag.
+
+### Milestone 4
+
+Implement escrow and atomic-swap state transitions on regtest.
+
+### Milestone 5
+
+Implement royalties, auctions, and voting on regtest and testnet.
+
+### Milestone 6
+
+Add deployment signaling and a future activation height after review.

--- a/src/assets/assetcontract.cpp
+++ b/src/assets/assetcontract.cpp
@@ -1,0 +1,126 @@
+// Copyright (c) 2026 The Yerbas Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "assets/assetcontract.h"
+
+#include "hash.h"
+
+namespace {
+
+bool IsKnownTemplate(AssetContractTemplate type)
+{
+    switch (type) {
+    case AssetContractTemplate::ESCROW:
+    case AssetContractTemplate::ROYALTY:
+    case AssetContractTemplate::AUCTION:
+    case AssetContractTemplate::ATOMIC_SWAP:
+    case AssetContractTemplate::VOTING:
+        return true;
+    case AssetContractTemplate::INVALID:
+        return false;
+    }
+    return false;
+}
+
+bool IsKnownCallOperation(AssetContractOperation operation)
+{
+    switch (operation) {
+    case AssetContractOperation::CALL:
+    case AssetContractOperation::CANCEL:
+    case AssetContractOperation::FINALIZE:
+        return true;
+    case AssetContractOperation::INVALID:
+    case AssetContractOperation::DEPLOY:
+        return false;
+    }
+    return false;
+}
+
+} // namespace
+
+bool CAssetContractDeploy::IsValid(std::string& strError) const
+{
+    strError.clear();
+
+    if (nVersion != ASSET_CONTRACT_PROTOCOL_VERSION) {
+        strError = "unsupported asset contract protocol version";
+        return false;
+    }
+
+    if (!IsKnownTemplate(nTemplate)) {
+        strError = "unknown asset contract template";
+        return false;
+    }
+
+    if (nTemplateVersion == 0) {
+        strError = "asset contract template version must be nonzero";
+        return false;
+    }
+
+    if (strAssetName.empty()) {
+        strError = "asset contract must specify a controlling asset";
+        return false;
+    }
+
+    if (ownerScript.empty()) {
+        strError = "asset contract owner script is empty";
+        return false;
+    }
+
+    if (vParameters.size() > MAX_ASSET_CONTRACT_DEPLOY_PAYLOAD) {
+        strError = "asset contract deployment payload exceeds limit";
+        return false;
+    }
+
+    if (nExecutionLimit == 0 || nExecutionLimit > MAX_ASSET_CONTRACT_OPERATIONS) {
+        strError = "asset contract execution limit is out of range";
+        return false;
+    }
+
+    return true;
+}
+
+bool CAssetContractCall::IsValid(std::string& strError) const
+{
+    strError.clear();
+
+    if (nVersion != ASSET_CONTRACT_PROTOCOL_VERSION) {
+        strError = "unsupported asset contract protocol version";
+        return false;
+    }
+
+    if (contractId.IsNull()) {
+        strError = "asset contract ID is null";
+        return false;
+    }
+
+    if (!IsKnownCallOperation(nOperation)) {
+        strError = "invalid asset contract call operation";
+        return false;
+    }
+
+    if (vArguments.size() > MAX_ASSET_CONTRACT_CALL_PAYLOAD) {
+        strError = "asset contract call payload exceeds limit";
+        return false;
+    }
+
+    if (nExecutionLimit == 0 || nExecutionLimit > MAX_ASSET_CONTRACT_OPERATIONS) {
+        strError = "asset contract execution limit is out of range";
+        return false;
+    }
+
+    if (nAttachedYerb < 0 || !MoneyRange(nAttachedYerb)) {
+        strError = "attached YERB amount is out of range";
+        return false;
+    }
+
+    return true;
+}
+
+uint256 GetAssetContractId(const COutPoint& deploymentOutpoint)
+{
+    CHashWriter ss(SER_GETHASH, 0);
+    ss << deploymentOutpoint;
+    return ss.GetHash();
+}

--- a/src/assets/assetcontract.h
+++ b/src/assets/assetcontract.h
@@ -1,0 +1,197 @@
+// Copyright (c) 2026 The Yerbas Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef YERBAS_ASSETCONTRACT_H
+#define YERBAS_ASSETCONTRACT_H
+
+#include "amount.h"
+#include "primitives/transaction.h"
+#include "script/script.h"
+#include "serialize.h"
+#include "uint256.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+static const uint16_t ASSET_CONTRACT_PROTOCOL_VERSION = 1;
+static const uint32_t MAX_ASSET_CONTRACT_DEPLOY_PAYLOAD = 4 * 1024;
+static const uint32_t MAX_ASSET_CONTRACT_CALL_PAYLOAD = 2 * 1024;
+static const uint32_t MAX_ASSET_CONTRACT_STATE_ENTRIES = 256;
+static const uint32_t MAX_ASSET_CONTRACT_STATE_KEY_SIZE = 64;
+static const uint32_t MAX_ASSET_CONTRACT_STATE_VALUE_SIZE = 512;
+static const uint32_t MAX_ASSET_CONTRACT_OPERATIONS = 1000;
+static const uint32_t MAX_ASSET_CONTRACTS_PER_TX = 8;
+static const uint16_t MAX_ASSET_CONTRACT_ROYALTY_BPS = 2500;
+
+/** Consensus-defined templates. No arbitrary executable bytecode is accepted. */
+enum class AssetContractTemplate : uint8_t
+{
+    INVALID = 0,
+    ESCROW = 1,
+    ROYALTY = 2,
+    AUCTION = 3,
+    ATOMIC_SWAP = 4,
+    VOTING = 5
+};
+
+enum class AssetContractOperation : uint8_t
+{
+    INVALID = 0,
+    DEPLOY = 1,
+    CALL = 2,
+    CANCEL = 3,
+    FINALIZE = 4
+};
+
+enum class AssetContractStatus : uint8_t
+{
+    INVALID = 0,
+    ACTIVE = 1,
+    COMPLETED = 2,
+    CANCELLED = 3,
+    EXPIRED = 4
+};
+
+/** Immutable contract deployment data. */
+class CAssetContractDeploy
+{
+public:
+    uint16_t nVersion;
+    AssetContractTemplate nTemplate;
+    uint16_t nTemplateVersion;
+    std::string strAssetName;
+    CScript ownerScript;
+    std::vector<unsigned char> vParameters;
+    uint32_t nExecutionLimit;
+
+    CAssetContractDeploy()
+    {
+        SetNull();
+    }
+
+    void SetNull()
+    {
+        nVersion = ASSET_CONTRACT_PROTOCOL_VERSION;
+        nTemplate = AssetContractTemplate::INVALID;
+        nTemplateVersion = 0;
+        strAssetName.clear();
+        ownerScript.clear();
+        vParameters.clear();
+        nExecutionLimit = 0;
+    }
+
+    bool IsNull() const
+    {
+        return nTemplate == AssetContractTemplate::INVALID;
+    }
+
+    bool IsValid(std::string& strError) const;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action)
+    {
+        READWRITE(nVersion);
+        READWRITE(nTemplate);
+        READWRITE(nTemplateVersion);
+        READWRITE(strAssetName);
+        READWRITE(ownerScript);
+        READWRITE(vParameters);
+        READWRITE(nExecutionLimit);
+    }
+};
+
+/** A bounded state transition request against an existing contract. */
+class CAssetContractCall
+{
+public:
+    uint16_t nVersion;
+    uint256 contractId;
+    AssetContractOperation nOperation;
+    uint16_t nMethod;
+    std::vector<unsigned char> vArguments;
+    uint32_t nExecutionLimit;
+    CAmount nAttachedYerb;
+
+    CAssetContractCall()
+    {
+        SetNull();
+    }
+
+    void SetNull()
+    {
+        nVersion = ASSET_CONTRACT_PROTOCOL_VERSION;
+        contractId.SetNull();
+        nOperation = AssetContractOperation::INVALID;
+        nMethod = 0;
+        vArguments.clear();
+        nExecutionLimit = 0;
+        nAttachedYerb = 0;
+    }
+
+    bool IsNull() const
+    {
+        return contractId.IsNull() || nOperation == AssetContractOperation::INVALID;
+    }
+
+    bool IsValid(std::string& strError) const;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action)
+    {
+        READWRITE(nVersion);
+        READWRITE(contractId);
+        READWRITE(nOperation);
+        READWRITE(nMethod);
+        READWRITE(vArguments);
+        READWRITE(nExecutionLimit);
+        READWRITE(nAttachedYerb);
+    }
+};
+
+/** Persisted metadata for one deployed contract. */
+class CAssetContractData
+{
+public:
+    CAssetContractDeploy deploy;
+    COutPoint deploymentOutpoint;
+    AssetContractStatus nStatus;
+    int nCreatedHeight;
+    int nUpdatedHeight;
+
+    CAssetContractData()
+    {
+        SetNull();
+    }
+
+    void SetNull()
+    {
+        deploy.SetNull();
+        deploymentOutpoint.SetNull();
+        nStatus = AssetContractStatus::INVALID;
+        nCreatedHeight = -1;
+        nUpdatedHeight = -1;
+    }
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action)
+    {
+        READWRITE(deploy);
+        READWRITE(deploymentOutpoint);
+        READWRITE(nStatus);
+        READWRITE(nCreatedHeight);
+        READWRITE(nUpdatedHeight);
+    }
+};
+
+/** Deterministically derive a contract ID from its deployment outpoint. */
+uint256 GetAssetContractId(const COutPoint& deploymentOutpoint);
+
+#endif // YERBAS_ASSETCONTRACT_H


### PR DESCRIPTION
Initial consensus-neutral scaffold for a constrained Yerbas Asset Contract layer supporting escrow, royalties, auctions, swaps, and voting. This draft PR is opened to run the repository build matrix. No activation or transaction parsing changes are included yet.